### PR TITLE
Update styling to add space between main image and description

### DIFF
--- a/_assets/_yearsite.scss
+++ b/_assets/_yearsite.scss
@@ -233,6 +233,10 @@ section.right a.right-off-canvas-toggle { margin-right: rem-calc(20); }
     figure {
       @include spacing;
 
+      img {
+        margin-bottom: rem-calc(20);
+      }
+
       figcaption a {
         color: $secondary-color;
         &:hover {


### PR DESCRIPTION
Adds space to the image page. 

Resolves https://github.com/tomnatt/year-in-pictures/issues/18