### PR TITLE
Add year to the page title

### DIFF
--- a/2015.html
+++ b/2015.html
@@ -7,7 +7,7 @@ months: true
 ---
 
 <section class="row month" id="january">
-  <h2>January</h2>
+  <h2>January {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 01-dad.jpg 2015 %}
@@ -21,7 +21,7 @@ months: true
 </section>
 
 <section class="row month" id="february">
-  <h2>February</h2>
+  <h2>February {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 02-dad.jpg 2015 %}
@@ -35,7 +35,7 @@ months: true
 </section>
 
 <section class="row month" id="march">
-  <h2>March</h2>
+  <h2>March {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 03-dad.jpg 2015 %}
@@ -49,7 +49,7 @@ months: true
 </section>
 
 <section class="row month" id="april">
-  <h2>April</h2>
+  <h2>April {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 04-dad.jpg 2015 %}
@@ -63,7 +63,7 @@ months: true
 </section>
 
 <section class="row month" id="may">
-  <h2>May</h2>
+  <h2>May {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 05-dad.jpg 2015 %}
@@ -77,7 +77,7 @@ months: true
 </section>
 
 <section class="row month" id="june">
-  <h2>June</h2>
+  <h2>June {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 06-dad.jpg 2015 %}
@@ -91,7 +91,7 @@ months: true
 </section>
 
 <section class="row month" id="july">
-  <h2>July</h2>
+  <h2>July {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 07-dad.jpg 2015 %}
@@ -105,7 +105,7 @@ months: true
 </section>
 
 <section class="row month" id="august">
-  <h2>August</h2>
+  <h2>August {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 08-dad.jpg 2015 %}
@@ -119,7 +119,7 @@ months: true
 </section>
 
 <section class="row month" id="september">
-  <h2>September</h2>
+  <h2>September {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 09-dad.jpg 2015 %}
@@ -133,7 +133,7 @@ months: true
 </section>
 
 <section class="row month" id="october">
-  <h2>October</h2>
+  <h2>October {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 10-dad.jpg 2015 %}
@@ -147,7 +147,7 @@ months: true
 </section>
 
 <section class="row month" id="november">
-  <h2>November</h2>
+  <h2>November {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 11-dad.jpg 2015 %}
@@ -161,7 +161,7 @@ months: true
 </section>
 
 <section class="row month" id="december">
-  <h2>December</h2>
+  <h2>December {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 12-dad.jpg 2015 %}

--- a/2016.html
+++ b/2016.html
@@ -7,7 +7,7 @@ months: true
 ---
 
 <section class="row month" id="january">
-  <h2>January</h2>
+  <h2>January {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 01-andrew.jpg 2016 %}
@@ -27,7 +27,7 @@ months: true
 </section>
 
 <section class="row month" id="february">
-  <h2>February</h2>
+  <h2>February {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 02-andrew.jpg 2016 %}
@@ -47,7 +47,7 @@ months: true
 </section>
 
 <section class="row month" id="march">
-  <h2>March</h2>
+  <h2>March {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 03-andrew.jpg 2016 %}
@@ -67,7 +67,7 @@ months: true
 </section>
 
 <section class="row month" id="april">
-  <h2>April</h2>
+  <h2>April {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 04-andrew.jpg 2016 %}
@@ -87,7 +87,7 @@ months: true
 </section>
 
 <section class="row month" id="may">
-  <h2>May</h2>
+  <h2>May {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 05-andrew.jpg 2016 %}
@@ -107,7 +107,7 @@ months: true
 </section>
 
 <section class="row month" id="june">
-  <h2>June</h2>
+  <h2>June {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 06-andrew.jpg 2016 %}
@@ -127,7 +127,7 @@ months: true
 </section>
 
 <section class="row month" id="july">
-  <h2>July</h2>
+  <h2>July {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 07-andrew.jpg 2016 %}
@@ -147,7 +147,7 @@ months: true
 </section>
 
 <section class="row month" id="august">
-  <h2>August</h2>
+  <h2>August {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 08-andrew.jpg 2016 %}
@@ -167,7 +167,7 @@ months: true
 </section>
 
 <section class="row month" id="september">
-  <h2>September</h2>
+  <h2>September {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 09-andrew.jpg 2016 %}
@@ -187,7 +187,7 @@ months: true
 </section>
 
 <section class="row month" id="october">
-  <h2>October</h2>
+  <h2>October {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 10-andrew.jpg 2016 %}
@@ -207,7 +207,7 @@ months: true
 </section>
 
 <section class="row month" id="november">
-  <h2>November</h2>
+  <h2>November {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 11-andrew.jpg 2016 %}
@@ -227,7 +227,7 @@ months: true
 </section>
 
 <section class="row month" id="december">
-  <h2>December</h2>
+  <h2>December {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 12-andrew.jpg 2016 %}

--- a/2017.html
+++ b/2017.html
@@ -6,7 +6,7 @@ months: true
 ---
 
 <section class="row month" id="january">
-  <h2>January</h2>
+  <h2>January {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 01-dad.jpg 2017 %}
@@ -29,7 +29,7 @@ months: true
 </section>
 
 <section class="row month" id="february">
-  <h2>February</h2>
+  <h2>February {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 02-dad.jpg 2017 %}
@@ -52,7 +52,7 @@ months: true
 </section>
 
 <section class="row month" id="march">
-  <h2>March</h2>
+  <h2>March {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 03-dad.jpg 2017 %}
@@ -75,7 +75,7 @@ months: true
 </section>
 
 <section class="row month" id="april">
-  <h2>April</h2>
+  <h2>April {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 04-dad.jpg 2017 %}
@@ -98,7 +98,7 @@ months: true
 </section>
 
 <section class="row month" id="may">
-  <h2>May</h2>
+  <h2>May {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 05-dad.jpg 2017 %}
@@ -121,7 +121,7 @@ months: true
 </section>
 
 <section class="row month" id="june">
-  <h2>June</h2>
+  <h2>June {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 06-dad.jpg 2017 %}
@@ -144,7 +144,7 @@ months: true
 </section>
 
 <section class="row month" id="july">
-  <h2>July</h2>
+  <h2>July {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 07-dad.jpg 2017 %}
@@ -167,7 +167,7 @@ months: true
 </section>
 
 <section class="row month" id="august">
-  <h2>August</h2>
+  <h2>August {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 08-dad.jpg 2017 %}
@@ -190,7 +190,7 @@ months: true
 </section>
 
 <section class="row month" id="september">
-  <h2>September</h2>
+  <h2>September {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 09-dad.jpg 2017 %}
@@ -213,7 +213,7 @@ months: true
 </section>
 
 <section class="row month" id="october">
-  <h2>October</h2>
+  <h2>October {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 10-dad.jpg 2017 %}
@@ -236,7 +236,7 @@ months: true
 </section>
 
 <section class="row month" id="november">
-  <h2>November</h2>
+  <h2>November {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 11-dad.jpg 2017 %}
@@ -259,7 +259,7 @@ months: true
 </section>
 
 <section class="row month" id="december">
-  <h2>December</h2>
+  <h2>December {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 12-dad.jpg 2017 %}

--- a/2018.html
+++ b/2018.html
@@ -6,7 +6,7 @@ months: true
 ---
 
 <section class="row month" id="january">
-  <h2>January</h2>
+  <h2>January {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 01-anna.jpg 2018 %}
@@ -35,7 +35,7 @@ months: true
 </section>
 
 <section class="row month" id="february">
-  <h2>February</h2>
+  <h2>February {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 02-anna.jpg 2018 %}
@@ -64,7 +64,7 @@ months: true
 </section>
 
 <section class="row month" id="march">
-  <h2>March</h2>
+  <h2>March {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 03-anna.jpg 2018 %}
@@ -93,7 +93,7 @@ months: true
 </section>
 
 <section class="row month" id="april">
-  <h2>April</h2>
+  <h2>April {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 04-anna.jpg 2018 %}
@@ -122,7 +122,7 @@ months: true
 </section>
 
 <section class="row month" id="may">
-  <h2>May</h2>
+  <h2>May {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 05-anna.jpg 2018 %}
@@ -151,7 +151,7 @@ months: true
 </section>
 
 <section class="row month" id="june">
-  <h2>June</h2>
+  <h2>June {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 06-anna.jpg 2018 %}
@@ -180,7 +180,7 @@ months: true
 </section>
 
 <section class="row month" id="july">
-  <h2>July</h2>
+  <h2>July {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 07-anna.jpg 2018 %}
@@ -209,7 +209,7 @@ months: true
 </section>
 
 <section class="row month" id="august">
-  <h2>August</h2>
+  <h2>August {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 08-anna.jpg 2018 %}
@@ -238,7 +238,7 @@ months: true
 </section>
 
 <section class="row month" id="september">
-  <h2>September</h2>
+  <h2>September {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 09-anna.jpg 2018 %}
@@ -267,7 +267,7 @@ months: true
 </section>
 
 <section class="row month" id="october">
-  <h2>October</h2>
+  <h2>October {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 10-anna.jpg 2018 %}
@@ -296,7 +296,7 @@ months: true
 </section>
 
 <section class="row month" id="november">
-  <h2>November</h2>
+  <h2>November {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 11-anna.jpg 2018 %}
@@ -325,7 +325,7 @@ months: true
 </section>
 
 <section class="row month" id="december">
-  <h2>December</h2>
+  <h2>December {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 12-anna.jpg 2018 %}

--- a/2019.html
+++ b/2019.html
@@ -6,7 +6,7 @@ months: true
 ---
 
 <section class="row month" id="january">
-  <h2>January</h2>
+  <h2>January {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 01-anna.jpg 2019 %}
@@ -41,7 +41,7 @@ months: true
 </section>
 
 <section class="row month" id="february">
-  <h2>February</h2>
+  <h2>February {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 02-anna.jpg 2019 %}
@@ -76,7 +76,7 @@ months: true
 </section>
 
 <section class="row month" id="march">
-  <h2>March</h2>
+  <h2>March {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 03-anna.jpg 2019 %}
@@ -111,7 +111,7 @@ months: true
 </section>
 
 <section class="row month" id="april">
-  <h2>April</h2>
+  <h2>April {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 04-anna.jpg 2019 %}
@@ -146,7 +146,7 @@ months: true
 </section>
 
 <section class="row month" id="may">
-  <h2>May</h2>
+  <h2>May {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 05-anna.jpg 2019 %}
@@ -181,7 +181,7 @@ months: true
 </section>
 
 <section class="row month" id="june">
-  <h2>June</h2>
+  <h2>June {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 06-anna.jpg 2019 %}
@@ -216,7 +216,7 @@ months: true
 </section>
 
 <section class="row month" id="july">
-  <h2>July</h2>
+  <h2>July {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 07-anna.jpg 2019 %}
@@ -250,7 +250,7 @@ months: true
 </section>
 
 <section class="row month" id="august">
-  <h2>August</h2>
+  <h2>August {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 08-amy.jpg 2019 %}
@@ -285,7 +285,7 @@ months: true
 </section>
 
 <section class="row month" id="september">
-  <h2>September</h2>
+  <h2>September {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 09-amy.jpg 2019 %}
@@ -320,7 +320,7 @@ months: true
 </section>
 
 <section class="row month" id="october">
-  <h2>October</h2>
+  <h2>October {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 10-amy.jpg 2019 %}
@@ -355,7 +355,7 @@ months: true
 </section>
 
 <section class="row month" id="november">
-  <h2>November</h2>
+  <h2>November {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 11-amy.jpg 2019 %}
@@ -390,7 +390,7 @@ months: true
 </section>
 
 <section class="row month" id="december">
-  <h2>December</h2>
+  <h2>December {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 12-amy.jpg 2019 %}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ months: true
 ---
 
 <section class="row month" id="january">
-  <h2>January</h2>
+  <h2>January {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 01-amy.jpg 2020 %}
@@ -43,7 +43,7 @@ months: true
 </section>
 
 <section class="row month" id="february">
-  <h2>February</h2>
+  <h2>February {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 02-amy.jpg 2020 %}
@@ -79,7 +79,7 @@ months: true
 </section>
 
 <section class="row month" id="march">
-  <h2>March</h2>
+  <h2>March {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 03-amy.jpg 2020 %}
@@ -115,7 +115,7 @@ months: true
 </section>
 
 <section class="row month" id="april">
-  <h2>April</h2>
+  <h2>April {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 04-amy.jpg 2020 %}
@@ -152,7 +152,7 @@ months: true
 </section>
 
 <section class="row month" id="may">
-  <h2>May</h2>
+  <h2>May {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 05-amy.jpg 2020 %}
@@ -189,7 +189,7 @@ months: true
 </section>
 
 <section class="row month" id="june">
-  <h2>June</h2>
+  <h2>June {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 06-amy.jpg 2020 %}
@@ -225,7 +225,7 @@ months: true
 </section>
 
 <section class="row month" id="july">
-  <h2>July</h2>
+  <h2>July {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 07-amy.jpg 2020 %}
@@ -263,7 +263,7 @@ months: true
 </section>
 
 <section class="row month" id="august">
-  <h2>August</h2>
+  <h2>August {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 08-amy.jpg 2020 %}
@@ -300,7 +300,7 @@ months: true
 </section>
 
 <section class="row month" id="september">
-  <h2>September</h2>
+  <h2>September {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 09-amy.jpg 2020 %}
@@ -338,7 +338,7 @@ months: true
 
 
 <section class="row month" id="october">
-  <h2>October</h2>
+  <h2>October {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 10-amy.jpg 2020 %}
@@ -375,7 +375,7 @@ months: true
 </section>
 
 <section class="row month" id="november">
-  <h2>November</h2>
+  <h2>November {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 11-amy.jpg 2020 %}
@@ -412,7 +412,7 @@ months: true
 </section>
 
 <section class="row month" id="december">
-  <h2>December</h2>
+  <h2>December {{ page.year }}</h2>
   <div class="images">
     <ul class="polaroids large-block-grid-3 small-block-grid-2">
 {% picture 12-amy.jpg 2020 %}


### PR DESCRIPTION
At the moment you can't see what year you are looking at as the page title only shows the month. I've added the year, drawn directly from the page front matter.